### PR TITLE
ci: add Python lint + coverage workflow

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install 'Flask<2.3' 'Jinja2<3.1' pytest pytest-cov flake8
+          pip install 'Flask<2.3' 'Jinja2<3.1' 'Werkzeug<1.0' 'itsdangerous<2.1' pytest pytest-cov flake8
 
       - name: Lint
         run: |

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest pytest-cov flake8
+          pip install 'Flask<2.3' 'Jinja2<3.1' pytest pytest-cov flake8
 
       - name: Lint
         run: |

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -1,0 +1,37 @@
+name: Python CI + Coverage
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest pytest-cov flake8
+
+      - name: Lint
+        run: |
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-line-length=127 --statistics
+
+      - name: Run tests with coverage (reporting-only gate)
+        run: |
+          pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=0
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for Python CI on push/PR
- run flake8 lint checks
- run pytest with coverage XML output
- upload coverage artifact for baseline reporting

## Coverage gate
- reporting-only (cov-fail-under=0) to establish baseline before enabling strict thresholds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to lint, test, and publish Python coverage on every push/PR to master/main. Uses a reporting-only coverage baseline and pins legacy Flask/Jinja/Werkzeug/itsdangerous versions for test compatibility.

- **New Features**
  - Lint with flake8 (errors flagged; style warnings non-blocking).
  - Run pytest on Python 3.11 with coverage (term + XML, cov-fail-under=0), installing Flask<2.3, Jinja2<3.1, Werkzeug<1.0, itsdangerous<2.1.
  - Upload coverage.xml as an artifact for baseline tracking.
  - Trigger on push and pull_request to master/main.

<sup>Written for commit ac75080d22c7ea5991c2fdc81105d61ebf69237d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI pipeline that runs on pushes and pull requests to execute Python 3.11 tests, perform dual-mode linting, and generate test coverage reports. Coverage is produced in human- and machine-readable formats and uploaded as an artifact to provide consistent automated quality checks and visibility into test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->